### PR TITLE
Enhance cartography table with map wipe, waypoint GUID tracking, and interaction cooldown

### DIFF
--- a/CakeBuild/CakeBuild.csproj
+++ b/CakeBuild/CakeBuild.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="3.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="6.1.0" />
     <PackageReference Include="Cake.Json" Version="7.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   
   <ItemGroup>

--- a/KsCartographyTable/KsCartographyTable.csproj
+++ b/KsCartographyTable/KsCartographyTable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin\$(Configuration)\Mods\mod</OutputPath>
   </PropertyGroup>

--- a/KsCartographyTable/assets/kscartographytable/blocktypes/cartography-table.json
+++ b/KsCartographyTable/assets/kscartographytable/blocktypes/cartography-table.json
@@ -3,7 +3,7 @@
 	"class": "kscartographytable.cartography-table",
     "entityClass": "kscartographytable.cartography-table-entity",
 	"blockmaterial": "wood",
-	"creativeinventory": { "general": ["*"], "blocks": ["*"] },
+	"creativeinventory": { "general": ["*"], "kscartographytable": ["*"] },
 	"texturesByType": {
 		"*": {
 			"sides": { "base": "block/cartography-table/sides" },

--- a/KsCartographyTable/assets/kscartographytable/lang/en.json
+++ b/KsCartographyTable/assets/kscartographytable/lang/en.json
@@ -1,8 +1,10 @@
 {
+	"game:tabname-kscartographytable": "K's Cartography",
 	"block-cartography-table": "Cartography table",
 	"blockdesc-cartography-table": "A tool to copy waypoints to and from a shared map.",
     "blockhelp-cartography-table-share-map": "Update the cartography table's map",
     "blockhelp-cartography-table-update-map": "Update your map",
+    "blockhelp-cartography-table-wipe-map": "Wipe the table's map",
 	"block-handbooktitle-cartography-table": "Cartography table",
 	"block-handbooktext-cartography-table": "Write your waypoints on the table by using ink and quill on it. Do the same while sprinting to copy the waypoints from the table to your map instead.",
     "gui-waypoint-count": "There are {0} waypoints on the map.\n",
@@ -14,6 +16,9 @@
     "message-edited-user-waypoints": "You modified {0} waypoints on your map.",
     "message-deleted-user-waypoints": "You removed {0} waypoints from your map.",
     "message-table-map-up-to-date": "The map on the table is already up to date.",
+    "message-user-map-up-to-date": "Your map is already up to date.",
+    "message-table-map-wiped": "{0} waypoints wiped from cartography table",
+    "message-table-map-already-empty": "Cartography table map is already empty",
     "message-user-map-up-to-date": "Your map is already up to date.",
     "gamemechanicinfo-sharingwaypoints-title": "Game Mechanic: Sharing Waypoints",
     "gamemechanicinfo-sharingwaypoints-text": "<strong>Sharing Waypoints</strong><br><br>A cartography table can be built in the crafting grid using a <a href=\"handbook://block-table-normal\">wooden table</a> and a <a href=\"handbook://item-paper-parchment\">parchment</a>. Once the cartography table is placed, <hk>rightmouse</hk>-click on it with an <a href=\"handbook://item-inkandquill\">ink and quill</a> in your main hand to update the cartography table's map with your changes, or <hk>ctrl</hk> + <hk>rightmouse</hk>-click an <a href=\"handbook://item-inkandquill\">ink and quill</a> in your main hand to update your map with the changes made by others.<br><br>Every table will have its own map, with an unique set of waypoints, so different groups of people can use different tables and only share waypoints within the group..<br><br><strong>Updating the cartography table's map</strong><br><br>When you update the cartography table's map:<br><br> - the waypoints you added on your map will be copied to the cartography table<br> - the waypoints you edited on your map will be updated on the cartography table<br> - the waypoints you deleted from your map will be deleted from the cartography table<br><br><strong>Updating your map</strong><br><br>When you update your map:<br><br> - the new waypoints on the cartography table will be added to your map<br> - the changed waypoints will be updated on your map<br> - the delted waypoints will be removed from your map<br><br>"

--- a/KsCartographyTable/modinfo.json
+++ b/KsCartographyTable/modinfo.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "type": "code",
     "modid": "kscartographytable",
     "name": "KsCartographyTable",
@@ -6,12 +6,12 @@
         "Kaisentlaia"
     ],
     "description": "A cartography table that allows waypoint sharing between players.",
-    "networkVersion": "1.0.1",
-    "version": "1.0.1",
+    "networkVersion": "1.0.3",
+    "version": "1.0.3",
     "side" : "Universal",
     "requiredOnClient": true,
     "requiredOnServer": true,
     "dependencies": {
-        "game": "1.19.0"
+        "game": "*"
     }
 }

--- a/KsCartographyTable/src/Block/BlockCartographyTable.cs
+++ b/KsCartographyTable/src/Block/BlockCartographyTable.cs
@@ -4,12 +4,15 @@ using Vintagestory.API.Client;
 using System.Collections.Generic;
 using Kaisentlaia.CartographyTable.BlockEntities;
 
-
 namespace Kaisentlaia.CartographyTable.Blocks
 {
     internal class BlockCartographyTable : Block
     {
         WorldInteraction[] interactions;
+        private Dictionary<string, long> lastInteractionTimes = new Dictionary<string, long>();
+        private const long InteractionCooldownMs = 500;
+        private const long EntryExpirationMs = 60000;
+
         public override void OnLoaded(ICoreAPI api)
         {
             base.OnLoaded(api);
@@ -25,6 +28,14 @@ namespace Kaisentlaia.CartographyTable.Blocks
                         List<ItemStack> stacks = inkAndQuill.GetHandBookStacks(capi);
                         if (stacks != null) inkAndQuillStackList.AddRange(stacks);
                     }
+
+                    List<ItemStack> resinStackList = new List<ItemStack>();
+                    var resin = api.World.Collectibles.Find(obj => obj.FirstCodePart() == "resin");
+                    if(resin != null) {
+                        List<ItemStack> stacks = resin.GetHandBookStacks(capi);
+                        if (stacks != null) resinStackList.AddRange(stacks);
+                    }
+
                     return new WorldInteraction[]
                     {
                         new WorldInteraction()
@@ -37,31 +48,88 @@ namespace Kaisentlaia.CartographyTable.Blocks
                         new WorldInteraction()
                         {
                             ActionLangCode = "kscartographytable:blockhelp-cartography-table-update-map",
-                            HotKeyCode = "sprint",                        
+                            HotKeyCode = "sprint",
                             MouseButton = EnumMouseButton.Right,
                             Itemstacks = inkAndQuillStackList.ToArray()
                         },
+                        new WorldInteraction()
+                        {
+                            ActionLangCode = "kscartographytable:blockhelp-cartography-table-wipe-map",
+                            HotKeyCode = null,
+                            MouseButton = EnumMouseButton.Right,
+                            Itemstacks = resinStackList.ToArray()
+                        }
                     };
                 }
             );
 
         }
+
+        private bool CanInteract(IPlayer player)
+        {
+            string playerKey = player.PlayerUID;
+            long currentTime = api.World.ElapsedMilliseconds;
+
+            if (lastInteractionTimes.TryGetValue(playerKey, out long lastTime))
+            {
+                if (currentTime - lastTime < InteractionCooldownMs)
+                {
+                    return false;
+                }
+            }
+
+            CleanupExpiredEntries(currentTime);
+            lastInteractionTimes[playerKey] = currentTime;
+            return true;
+        }
+
+        private void CleanupExpiredEntries(long currentTime)
+        {
+            var keysToRemove = new List<string>();
+            foreach (var kvp in lastInteractionTimes)
+            {
+                if (currentTime - kvp.Value > EntryExpirationMs)
+                {
+                    keysToRemove.Add(kvp.Key);
+                }
+            }
+            foreach (var key in keysToRemove)
+            {
+                lastInteractionTimes.Remove(key);
+            }
+        }
+
         public override bool OnBlockInteractStart(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel)
         {
-            // TODO prevent multiple consequent executions
+            // Prevent multiple rapid interactions
+            if (!CanInteract(byPlayer))
+            {
+                return true; // Block the interaction but return true to prevent other handlers
+            }
+
             BlockEntityCartographyTable BlockEntityCartographyTable = world.BlockAccessor.GetBlockEntity(blockSel.Position) as BlockEntityCartographyTable;
 
             if (BlockEntityCartographyTable != null) {
                 ItemSlot slot = byPlayer.InventoryManager.ActiveHotbarSlot;
 
-                if (slot.Itemstack != null && slot.Itemstack.Collectible.FirstCodePart() == "inkandquill" && !byPlayer.Entity.Controls.Sneak) {      
+                // Wipe table map with resin
+                if (slot?.Itemstack != null && slot.Itemstack.Collectible.FirstCodePart() == "resin") 
+                {
+                    return BlockEntityCartographyTable.OnWipeTableMap(world, byPlayer, blockSel);
+                }
+                // Update cartography table or player map with ink and quill
+                else if (slot?.Itemstack != null && 
+                         slot.Itemstack.Collectible.FirstCodePart() == "inkandquill" && 
+                         !byPlayer.Entity.Controls.Sneak) 
+                {      
                     return BlockEntityCartographyTable.OnPlayerInteract(world, byPlayer, blockSel);
-                } else if(byPlayer.Entity.LeftHandItemSlot?.Itemstack?.Collectible?.FirstCodePart() == "resin" && slot.Itemstack != null && slot.Itemstack.Collectible.FirstCodePart() == "parchment") {   
-                    // TODO wipe table map  
-                    return base.OnBlockInteractStart(world, byPlayer, blockSel);
-                } else if(KsCartographyTableModSystem.purgeWpGroups) {
+                }
+                // Purge waypoint groups (command-triggered)
+                else if(KsCartographyTableModSystem.purgeWpGroups) 
+                {
                     return BlockEntityCartographyTable.OnPurgeWaypointGroups(world, byPlayer, blockSel);
                 }
+                
                 return base.OnBlockInteractStart(world, byPlayer, blockSel);
             }
             

--- a/KsCartographyTable/src/BlockEntity/BECartographyTable.cs
+++ b/KsCartographyTable/src/BlockEntity/BECartographyTable.cs
@@ -23,7 +23,6 @@ namespace Kaisentlaia.CartographyTable.BlockEntities
     {        
         private ICoreServerAPI CoreServerAPI;
         private ICoreClientAPI CoreClientAPI;
-        public CartographyHelper CartographyHelper;
         private CartographyMap Map;
 
         public override void Initialize(ICoreAPI api)
@@ -32,7 +31,6 @@ namespace Kaisentlaia.CartographyTable.BlockEntities
 
             if(Api.Side == EnumAppSide.Server) {
                 CoreServerAPI = Api as ICoreServerAPI;
-                CartographyHelper = new CartographyHelper(CoreServerAPI);
             }
             if(Api.Side == EnumAppSide.Client) {
                 CoreClientAPI = Api as ICoreClientAPI;
@@ -42,16 +40,49 @@ namespace Kaisentlaia.CartographyTable.BlockEntities
         public override void OnBlockPlaced(ItemStack byItemStack = null)
         {
             base.OnBlockPlaced(byItemStack);
-            if (CartographyHelper != null) {
-                CartographyHelper.Map = new CartographyMap();
+            if (Map == null) {
+                Map = new CartographyMap();
             }
         }
 
         internal bool OnPurgeWaypointGroups(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel)
         {
             if (CoreServerAPI != null && KsCartographyTableModSystem.purgeWpGroups) {
-                CartographyHelper.PurgeWaypointGroups(byPlayer);
+                KsCartographyTableModSystem.CartographyHelper.PurgeWaypointGroups(byPlayer);
             }
+            return true;
+        }
+
+        internal bool OnWipeTableMap(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel)
+        {
+            if (CoreServerAPI != null) 
+            {
+                if (Map != null && Map.Waypoints.Count > 0)
+                {
+                    int waypointCount = Map.Waypoints.Count;
+                    KsCartographyTableModSystem.CartographyHelper.WipeTableMap(Map);
+                    Map = new CartographyMap();
+                    MarkDirty();
+                    
+                    CoreServerAPI.SendMessage(byPlayer, GlobalConstants.GeneralChatGroup, 
+                        Lang.Get("kscartographytable:message-table-map-wiped", waypointCount), 
+                        EnumChatType.Notification);
+                    
+                    byPlayer.Entity.World.PlaySoundAt(new AssetLocation("game:sounds/effect/writing"), byPlayer);
+                }
+                else
+                {
+                    CoreServerAPI.SendMessage(byPlayer, GlobalConstants.GeneralChatGroup, 
+                        Lang.Get("kscartographytable:message-table-map-already-empty"), 
+                        EnumChatType.Notification);
+                }
+            }
+            
+            if (CoreClientAPI != null) 
+            {
+                CoreClientAPI.World.Player.TriggerFpAnimation(EnumHandInteract.BlockInteract);
+            }
+
             return true;
         }
 
@@ -59,12 +90,10 @@ namespace Kaisentlaia.CartographyTable.BlockEntities
         {
             if (CoreServerAPI != null) {
                 if (!byPlayer.Entity.Controls.Sprint) {
-                    CartographyHelper.Map = Map;
-                    Map = CartographyHelper.updateTableMap(byPlayer as IServerPlayer);
+                    KsCartographyTableModSystem.CartographyHelper.UpdateTableMap(Map, byPlayer as IServerPlayer);
                     MarkDirty();
                 } else if (byPlayer.Entity.Controls.Sprint) {
-                    CartographyHelper.Map = Map;
-                    CartographyHelper.updatePlayerMap(byPlayer as IServerPlayer);
+                    KsCartographyTableModSystem.CartographyHelper.UpdatePlayerMap(Map, byPlayer as IServerPlayer);
                 }
             }
             if (CoreClientAPI != null) {
@@ -73,6 +102,7 @@ namespace Kaisentlaia.CartographyTable.BlockEntities
 
             return true;
         }
+        
         public override void GetBlockInfo(IPlayer forPlayer, StringBuilder dsc) {
             if (Map != null && Map.Waypoints.Count > 0) {
                 dsc.AppendLine(Lang.Get("kscartographytable:gui-waypoint-count", Map.Waypoints.Count));
@@ -84,18 +114,17 @@ namespace Kaisentlaia.CartographyTable.BlockEntities
         public override void ToTreeAttributes(ITreeAttribute tree)
         {
             base.ToTreeAttributes(tree);
-            // bytes would be better, but they cause exceptions
             if (Map != null) {
                 try {
                     tree.SetString("Waypoints", JsonUtil.ToString(Map.Waypoints));
                 } catch (Exception ex) {
-                    Api.Logger.Error(ex.StackTrace);
+                    Api.Logger.Error("Failed to serialize waypoints: {0}", ex);
                     tree.SetString("Waypoints", JsonUtil.ToString(new List<CartographyWaypoint>()));
                 }
                 try {
                     tree.SetString("DeletedWaypoints", JsonUtil.ToString(Map.DeletedWaypoints));
                 } catch (Exception ex) {
-                    Api.Logger.Error(ex.StackTrace);
+                    Api.Logger.Error("Failed to serialize deleted waypoints: {0}", ex);
                     tree.SetString("DeletedWaypoints", JsonUtil.ToString(new List<CartographyWaypoint>()));
                 }
             } else {
@@ -110,39 +139,31 @@ namespace Kaisentlaia.CartographyTable.BlockEntities
             if (Map == null) {
                 Map = new CartographyMap();
             }
-            // bytes would be better, but they cause exceptions
             try {
                 if(tree.HasAttribute("Waypoints")) {
                     var savedWaypoints = tree.GetString("Waypoints");
-                    if (savedWaypoints != null) {
-                        Map.Waypoints = JsonUtil.FromString<List<CartographyWaypoint>>(savedWaypoints); 
-                    } else {
-                        Map.Waypoints = new List<CartographyWaypoint>();
-                    }
+                    Map.Waypoints = savedWaypoints != null 
+                        ? JsonUtil.FromString<List<CartographyWaypoint>>(savedWaypoints) 
+                        : new List<CartographyWaypoint>();
                 } else {
                     Map.Waypoints = new List<CartographyWaypoint>();
                 }
             } catch (Exception ex) {
-                Api.Logger.Error(ex.StackTrace);
+                Api.Logger.Error("Failed to deserialize waypoints: {0}", ex);
                 Map.Waypoints = new List<CartographyWaypoint>();
             }
             try {
                 if(tree.HasAttribute("DeletedWaypoints")) {
                     var deletedWaypoints = tree.GetString("DeletedWaypoints");
-                    if (tree.GetString("DeletedWaypoints") != null) {
-                        Map.DeletedWaypoints = JsonUtil.FromString<List<CartographyWaypoint>>(deletedWaypoints); 
-                    } else {
-                        Map.DeletedWaypoints = new List<CartographyWaypoint>();
-                    }
+                    Map.DeletedWaypoints = deletedWaypoints != null 
+                        ? JsonUtil.FromString<List<CartographyWaypoint>>(deletedWaypoints) 
+                        : new List<CartographyWaypoint>();
                 } else {
                     Map.DeletedWaypoints = new List<CartographyWaypoint>();
                 }
             } catch (Exception ex) {
-                Api.Logger.Error(ex.StackTrace);
+                Api.Logger.Error("Failed to deserialize deleted waypoints: {0}", ex);
                 Map.DeletedWaypoints = new List<CartographyWaypoint>();
-            }
-            if (CartographyHelper != null) {
-                CartographyHelper.Map = Map;
             }
         }
     }

--- a/KsCartographyTable/src/GameContent/CartographyMap.cs
+++ b/KsCartographyTable/src/GameContent/CartographyMap.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Vintagestory.API.Common;
 using Vintagestory.GameContent;
 
@@ -32,8 +33,8 @@ namespace Kaisentlaia.CartographyTable.GameContent
         }
 
         public CartographyMap(List<Waypoint> InitialWaypoints = null, List<Waypoint> InitialDeletedWaypoints = null, IPlayer player = null) {
-            Waypoints = null;
-            DeletedWaypoints = null;
+            waypoints = new List<CartographyWaypoint>();
+            deletedWaypoints = new List<CartographyWaypoint>();
             if (InitialWaypoints != null && player != null) {
                 InitialWaypoints.ForEach(waypoint => {
                     waypoints.Add(new CartographyWaypoint(waypoint, player));
@@ -48,69 +49,55 @@ namespace Kaisentlaia.CartographyTable.GameContent
 
         public void Create(Waypoint waypoint, IPlayer player) {
             if(Contains(waypoint)) {
-                // failsafe, already exists, avoid duplication
                 Update(waypoint, player);
             } else {
                 waypoints.Add(new CartographyWaypoint(waypoint, player));
             }
             if (HasDeleted(waypoint)) {
-                Console.WriteLine("warning - added waypoint present in deleted waypoints");
                 Undelete(waypoint);
             }
         }
 
         public void Update(Waypoint waypoint, IPlayer player) {
-            if(Contains(waypoint)) {
-                var toEdit = Find(waypoint);
-                if (toEdit != null) {
-                    toEdit.Color = waypoint.Color;
-                    toEdit.Icon = waypoint.Icon;
-                    toEdit.Pinned = waypoint.Pinned;
-                    toEdit.Title = waypoint.Title;
-                    toEdit.OwningPlayerUid = player.PlayerUID;
-                    toEdit.Modified = DateTime.Now;
-                    toEdit.ModifiedByPlayerUid = player.PlayerUID;
-                } else {
-                    // failsafe, didn't exist
-                    Console.WriteLine("warning - no waypoint to edit");
-                    Create(waypoint, player);
-                }
+            var existing = Find(waypoint);
+            if (existing != null) {
+                existing.Color = waypoint.Color;
+                existing.Icon = waypoint.Icon;
+                existing.Pinned = waypoint.Pinned;
+                existing.Title = waypoint.Title;
+                existing.OwningPlayerUid = player.PlayerUID;
+                existing.Modified = DateTime.Now;
+                existing.ModifiedByPlayerUid = player.PlayerUID;
             } else {
-                // failsafe, didn't exist
                 waypoints.Add(new CartographyWaypoint(waypoint, player));
-                Create(waypoint, player);
             }
-            if (deletedWaypoints.Find(dwp => dwp.CorrespondsTo(waypoint)) != null) {
-                Console.WriteLine("warning - created waypoint present in deleted waypoints");
+            if (deletedWaypoints.Any(dwp => dwp.Guid == waypoint.Guid)) {
                 Undelete(waypoint);
             }
         }
 
         public void Delete(Waypoint waypoint) {
-            var toDelete = Find(waypoint);
+            var toDelete = waypoints.FirstOrDefault(wp => wp.Guid == waypoint.Guid);
             if (toDelete != null) {
-                if(!HasDeleted(waypoint)) {
+                if (!deletedWaypoints.Any(dwp => dwp.Guid == waypoint.Guid)) {
                     deletedWaypoints.Add(toDelete);
                 }
-                if(Contains(waypoint)) {
-                    waypoints.Remove(toDelete);
-                }
+                waypoints.Remove(toDelete);
             }
         }
 
         private void Undelete(Waypoint waypoint) {
-            var toUndelete = FindDeleted(waypoint);
-            if(toUndelete != null) {
+            var toUndelete = deletedWaypoints.FirstOrDefault(dwp => dwp.Guid == waypoint.Guid);
+            if (toUndelete != null) {
                 deletedWaypoints.Remove(toUndelete);
             }
-
         }
 
         public CartographyWaypoint Find(Waypoint waypoint) {
-            return waypoints.Find(wp => wp.CorrespondsTo(waypoint));
+            return waypoints.FirstOrDefault(wp => wp.Guid == waypoint.Guid);
         }
         public CartographyWaypoint FindDeleted(Waypoint waypoint) {
-            return deletedWaypoints.Find(wp => wp.CorrespondsTo(waypoint));
+            return deletedWaypoints.FirstOrDefault(wp => wp.Guid == waypoint.Guid);
         }
 
         public bool Contains(Waypoint waypoint, bool sameContent = false) {
@@ -132,7 +119,7 @@ namespace Kaisentlaia.CartographyTable.GameContent
         }
 
         public bool HasDeleted(Waypoint waypoint) {
-            return FindDeleted(waypoint) != null;
+            return deletedWaypoints.Any(dwp => dwp.Guid == waypoint.Guid);
         }
     }
 }

--- a/KsCartographyTable/src/GameContent/CartographyWaypoint.cs
+++ b/KsCartographyTable/src/GameContent/CartographyWaypoint.cs
@@ -34,7 +34,7 @@ namespace Kaisentlaia.CartographyTable.GameContent
         }
 
         public bool CorrespondsTo(Waypoint waypoint) {
-            return Position.Equals(waypoint.Position);
+            return Guid == waypoint.Guid;
         }
 
         public bool CreatedBy(IPlayer player) {

--- a/KsCartographyTable/src/GameContent/GuiDialogCartographyMap.cs
+++ b/KsCartographyTable/src/GameContent/GuiDialogCartographyMap.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Vintagestory.API.Client;
 using Vintagestory.GameContent;
 
@@ -6,7 +6,7 @@ namespace Kaisentlaia.CartographyTable.GameContent
 {
     public class GuiDialogCartographyMap : GuiDialogWorldMap
     {
-        public GuiDialogCartographyMap(OnViewChangedDelegate viewChanged, ICoreClientAPI capi, List<string> tabnames) : base(viewChanged, capi, tabnames)
+        public GuiDialogCartographyMap(OnViewChangedDelegate viewChanged, OnViewChangedSyncDelegate viewChangedSync, ICoreClientAPI capi, List<string> tabnames) : base(viewChanged, viewChangedSync, capi, tabnames)
         {
         }
     }

--- a/KsCartographyTable/src/Server/CartographyHelper.cs
+++ b/KsCartographyTable/src/Server/CartographyHelper.cs
@@ -13,18 +13,8 @@ namespace Kaisentlaia.CartographyTable.Utilities
     public class CartographyHelper {
         ICoreServerAPI CoreServerAPI;
         WorldMapManager WorldMapManager;
-        private CartographyMap map;
-        public CartographyMap Map {
-            get { return map; }
-            set {                
-                if (value != null) {
-                    map = value;
-                } else {
-                    map = new CartographyMap();
-                }
-            }
-        }
         WaypointMapLayer WaypointMapLayer;
+
         public CartographyHelper(ICoreServerAPI ServerAPI) {
             CoreServerAPI = ServerAPI;
             SetWaypointMapLayer();
@@ -39,17 +29,23 @@ namespace Kaisentlaia.CartographyTable.Utilities
             }
         }
 
-        public CartographyMap updateTableMap(IServerPlayer player) {
+        public void UpdateTableMap(CartographyMap map, IServerPlayer player) {
             SetWaypointMapLayer();
-            var playerWaypoints = getPlayerWaypoints(player);
+            var playerWaypoints = GetPlayerWaypoints(player);
             var playerDeletedWaypoints = GetPlayerDeletedWaypoints(player);
-            var playerMap = new CartographyMap(playerWaypoints, playerDeletedWaypoints, player);
-            var sharedWaypoints = map.Waypoints;
-            var deletedWaypoints = map.DeletedWaypoints;
 
-            var toAdd = playerWaypoints.FindAll(PlayerWaypoint => !map.Contains(PlayerWaypoint));
-            var toUpdate = playerWaypoints.FindAll(PlayerWaypoint => map.Contains(PlayerWaypoint) && !map.Contains(PlayerWaypoint, true));
-            var toDelete = playerDeletedWaypoints.FindAll(PlayerWaypoint => map.Contains(PlayerWaypoint));
+            var tableGuids = map.Waypoints.Select(wp => wp.Guid).ToHashSet();
+            
+            var toAdd = playerWaypoints.Where(PlayerWaypoint => !tableGuids.Contains(PlayerWaypoint.Guid)).ToList();
+            var toUpdate = playerWaypoints.Where(PlayerWaypoint => {
+                var tableWaypoint = map.Waypoints.FirstOrDefault(wp => wp.Guid == PlayerWaypoint.Guid);
+                if (tableWaypoint == null) return false;
+                return tableWaypoint.Icon != PlayerWaypoint.Icon ||
+                       tableWaypoint.Color != PlayerWaypoint.Color ||
+                       tableWaypoint.Title != PlayerWaypoint.Title ||
+                       tableWaypoint.Pinned != PlayerWaypoint.Pinned;
+            }).ToList();
+            var toDelete = playerDeletedWaypoints.Where(PlayerWaypoint => tableGuids.Contains(PlayerWaypoint.Guid)).ToList();
             
             toAdd.ForEach(PlayerWaypoint => {
                 map.Create(PlayerWaypoint, player);
@@ -78,22 +74,36 @@ namespace Kaisentlaia.CartographyTable.Utilities
             } else {
                 CoreServerAPI.SendMessage(player, GlobalConstants.GeneralChatGroup, Lang.Get("kscartographytable:message-table-map-up-to-date"), EnumChatType.Notification);
             }
-            return map;
         }
 
-        public void updatePlayerMap(IServerPlayer player) {
+        public void UpdatePlayerMap(CartographyMap map, IServerPlayer player) {
             SetWaypointMapLayer();
 
-            var playerWaypoints = getPlayerWaypoints(player);
-            var worldDeletedWaypoints = GetPlayerDeletedWaypoints();
-            var playerMap = new CartographyMap(playerWaypoints, worldDeletedWaypoints, player);
-            var sharedWaypoints = map.Waypoints;
-            var deletedWaypoints = map.DeletedWaypoints;
+            var playerWaypoints = GetPlayerWaypoints(player);
+            var tableDeletedWaypoints = map.DeletedWaypoints;
 
-            var onlyOnTableMapToAdd = sharedWaypoints.FindAll(SharedWaypoint => !playerMap.Contains(SharedWaypoint));
-            var onBothMaps = sharedWaypoints.FindAll(SharedWaypoint => playerMap.Contains(SharedWaypoint));
-            var onBothMapsToEdit = sharedWaypoints.FindAll(SharedWaypoint => playerMap.Contains(SharedWaypoint) && !playerMap.Contains(SharedWaypoint, true));
-            var onlyOnPlayerMapToDelete = playerWaypoints.FindAll(PlayerWaypoint => !map.Contains(PlayerWaypoint) && map.HasDeleted(PlayerWaypoint));
+            var playerGuids = playerWaypoints.Select(pw => pw.Guid).ToHashSet();
+            var tableGuids = map.Waypoints.Select(wp => wp.Guid).ToHashSet();
+            var deletedGuids = tableDeletedWaypoints.Select(dw => dw.Guid).ToHashSet();
+
+            var onlyOnTableMapToAdd = map.Waypoints.Where(SharedWaypoint => 
+                !playerGuids.Contains(SharedWaypoint.Guid)).ToList();
+
+            var onBothMapsToEdit = map.Waypoints.Where(SharedWaypoint => {
+                var existingWaypoint = playerWaypoints.FirstOrDefault(pw => pw.Guid == SharedWaypoint.Guid);
+                return existingWaypoint != null && (
+                    existingWaypoint.Color != SharedWaypoint.Color ||
+                    existingWaypoint.Icon != SharedWaypoint.Icon ||
+                    existingWaypoint.Pinned != SharedWaypoint.Pinned ||
+                    existingWaypoint.Title != SharedWaypoint.Title
+                );
+            }).ToList();
+
+            var onlyOnPlayerMapToDelete = playerWaypoints.Where(PlayerWaypoint => {
+                bool notOnTable = !tableGuids.Contains(PlayerWaypoint.Guid);
+                bool markedDeletedOnTable = deletedGuids.Contains(PlayerWaypoint.Guid);
+                return notOnTable && markedDeletedOnTable;
+            }).ToList();
 
             onlyOnTableMapToAdd.ForEach(SharedWaypoint => {
                 Waypoint waypoint = new Waypoint()
@@ -110,8 +120,8 @@ namespace Kaisentlaia.CartographyTable.Utilities
                 WaypointMapLayer.AddWaypoint(waypoint, player);
             });
 
-            onBothMapsToEdit.Foreach(SharedWaypoint => {
-                var PlayerWaypoint = WaypointMapLayer.Waypoints.Find(waypoint => SharedWaypoint.CorrespondsTo(waypoint));
+            onBothMapsToEdit.ForEach(SharedWaypoint => {
+                var PlayerWaypoint = playerWaypoints.FirstOrDefault(pw => pw.Guid == SharedWaypoint.Guid);
                 if (PlayerWaypoint != null) {
                     PlayerWaypoint.Color = SharedWaypoint.Color;
                     PlayerWaypoint.Icon = SharedWaypoint.Icon;
@@ -121,19 +131,23 @@ namespace Kaisentlaia.CartographyTable.Utilities
                 }
             });
 
-            onlyOnPlayerMapToDelete.Foreach(PlayerWaypoint => {
-                var toDelete = WaypointMapLayer.Waypoints.Find(waypoint => waypoint.Position.Equals(PlayerWaypoint.Position));
-                WaypointMapLayer.Waypoints.Remove(toDelete);
+            bool anyDeleted = false;
+            onlyOnPlayerMapToDelete.ForEach(PlayerWaypoint => {
+                var toDelete = WaypointMapLayer.Waypoints.FirstOrDefault(wp => wp.Guid == PlayerWaypoint.Guid);
+                if (toDelete != null) {
+                    WaypointMapLayer.Waypoints.Remove(toDelete);
+                    anyDeleted = true;
+                }
             });
 
-            if (onlyOnTableMapToAdd.Count > 0 || onBothMapsToEdit.Count > 0 || onlyOnPlayerMapToDelete.Count > 0) {
+            if (onlyOnTableMapToAdd.Count > 0 || onBothMapsToEdit.Count > 0 || anyDeleted) {
                 if (onlyOnTableMapToAdd.Count > 0) {
-                    CoreServerAPI.SendMessage(player, GlobalConstants.GeneralChatGroup, Lang.Get("kscartographytable:message-new-user-waypoints", onlyOnTableMapToAdd.Count, onBothMapsToEdit.Count), EnumChatType.Notification);
+                    CoreServerAPI.SendMessage(player, GlobalConstants.GeneralChatGroup, Lang.Get("kscartographytable:message-new-user-waypoints", onlyOnTableMapToAdd.Count), EnumChatType.Notification);
                 }
                 if (onBothMapsToEdit.Count > 0) {
-                    CoreServerAPI.SendMessage(player, GlobalConstants.GeneralChatGroup, Lang.Get("kscartographytable:message-edited-user-waypoints", onBothMapsToEdit.Count, onBothMapsToEdit.Count), EnumChatType.Notification);
+                    CoreServerAPI.SendMessage(player, GlobalConstants.GeneralChatGroup, Lang.Get("kscartographytable:message-edited-user-waypoints", onBothMapsToEdit.Count), EnumChatType.Notification);
                 }
-                if (onlyOnPlayerMapToDelete.Count > 0) {
+                if (anyDeleted) {
                     CoreServerAPI.SendMessage(player, GlobalConstants.GeneralChatGroup, Lang.Get("kscartographytable:message-deleted-user-waypoints", onlyOnPlayerMapToDelete.Count), EnumChatType.Notification);
                 }
                 player.Entity.World.PlaySoundAt(new AssetLocation("game:sounds/effect/writing"),player);
@@ -143,7 +157,7 @@ namespace Kaisentlaia.CartographyTable.Utilities
             }
         }
 
-        public List<Waypoint> getPlayerWaypoints(IServerPlayer player) {
+        public List<Waypoint> GetPlayerWaypoints(IServerPlayer player) {
             List<Waypoint> waypoints = new List<Waypoint>();
             if (WaypointMapLayer != null) {
                 waypoints = WaypointMapLayer.Waypoints.FindAll(PlayerWaypoint => PlayerWaypoint.OwningPlayerUid == player.PlayerUID);
@@ -164,24 +178,39 @@ namespace Kaisentlaia.CartographyTable.Utilities
             }
         }
 
+        public void WipeTableMap(CartographyMap map) {
+            if (map != null) {
+                map.Waypoints.Clear();
+                map.DeletedWaypoints.Clear();
+                CoreServerAPI.SendMessage(null, GlobalConstants.GeneralChatGroup, Lang.Get("kscartographytable:message-table-map-wiped", 0), EnumChatType.Notification);
+            } else {
+                CoreServerAPI.SendMessage(null, GlobalConstants.GeneralChatGroup, Lang.Get("kscartographytable:message-table-map-already-empty"), EnumChatType.Notification);
+            }
+        }
+
         private List<Waypoint> GetPlayerDeletedWaypoints(IPlayer player = null) {
             byte[] data = CoreServerAPI.WorldManager.SaveGame.GetData("deletedWaypoints");
             var deletedWaypoints = data == null ? new List<Waypoint>() : SerializerUtil.Deserialize<List<Waypoint>>(data);
-            if(player != null) {
-                deletedWaypoints = deletedWaypoints.FindAll(waypoint => waypoint.OwningPlayerUid == player.PlayerUID);
+            if (player != null) {
+                return deletedWaypoints.Where(waypoint => waypoint.OwningPlayerUid == player.PlayerUID).ToList();
             }
             return deletedWaypoints;
         }
 
         public void MarkDeleted(IServerPlayer player, int index) {
             SetWaypointMapLayer();
-            Waypoint[] array = WaypointMapLayer.Waypoints.Where((Waypoint p) => p.OwningPlayerUid == player.PlayerUID).ToArray();
-            if (array.Length > 0 && index >=0 && index < array.Length) {
-                Waypoint waypoint = array[index];
-                var deletedWaypoints = GetPlayerDeletedWaypoints();
-                if (deletedWaypoints.Find(dwp => dwp.Guid == waypoint.Guid) == null) {
-                    deletedWaypoints.Add(waypoint);
-                }
+            var playerWaypoints = WaypointMapLayer.Waypoints
+                .Where(p => p.OwningPlayerUid == player.PlayerUID)
+                .ToList();
+            
+            if (index < 0 || index >= playerWaypoints.Count) {
+                return;
+            }
+            
+            Waypoint waypoint = playerWaypoints[index];
+            var deletedWaypoints = GetPlayerDeletedWaypoints();
+            if (!deletedWaypoints.Any(dwp => dwp.Guid == waypoint.Guid)) {
+                deletedWaypoints.Add(waypoint);
                 CoreServerAPI.WorldManager.SaveGame.StoreData("deletedWaypoints", SerializerUtil.Serialize(deletedWaypoints));
             }
         }

--- a/README.md
+++ b/README.md
@@ -78,3 +78,5 @@ _\*Blackjack and hookers not included._
 
 1.  v1.0.0 - Initial release
 2.  v1.0.1 - Deleted waypoints will be removed from the player's map on update - experimental
+3.  v1.0.2 - Added interaction cooldown to prevent spam, added map wipe with resin
+4.  v1.0.3 - Bug fixes: Fixed null reference in CartographyMap, removed duplicate waypoint creation, corrected chat message parameters, fixed waypoint tracking using GUID instead of position, improved sync logic between tables and player maps


### PR DESCRIPTION
### New Features
- Map wipe with resin players can now wipe the cartography table's map using resin (right-click with resin)
- Interaction cooldown prevents spam clicking with a 500ms cooldown per player

### Improvements
- Waypoints are now tracked by their unique GUID instead of position, fixing issues where waypoints at the same position would be incorrectly matched
- Refactored CartographyMap with a cleaner separation of concerns for map data handling
- Improved synchronization between table maps and player maps

### Technical Changes
- Updated target framework to .NET 10.0 (1.22)
- Updated Cake build packages
- Added new localization strings for wipe functionality

### Files Changed
| File | Changes |
|------|---------|
| `BlockCartographyTable.cs` | Added cooldown, resin wipe interaction |
| `BECartographyTable.cs` | Simplified map handling |
| `CartographyMap.cs` | Refactored with GUID tracking, LINQ |
| `CartographyWaypoint.cs` | GUID-based comparison |
| `CartographyHelper.cs` | Refactored sync logic |
| `GuiDialogCartographyMap.cs` | Updated constructor for view sync |
| `modinfo.json` | Version bump to 1.0.3 |
| `cartography-table.json` | Creative inventory fix |
| `en.json` | New strings for wipe feature |
| Build configs | .NET 10.0, package updates |

### Why These Changes
- GUID tracking: Position-based matching caused bugs when multiple waypoints existed at the same location
- Resin wipe: Provides a way to reset table maps
- Cooldown: Prevents accidental double-interactions
- Cleaner code: Removed debug statements, simplified logic